### PR TITLE
Reset state of random number generator for each event

### DIFF
--- a/Calo/BuildFile.xml
+++ b/Calo/BuildFile.xml
@@ -4,7 +4,10 @@
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>
+<use name="FWCore/Utilities"/>
 <use name="CommonTools/UtilAlgos"/>
+<use name="IOMC/RandomEngine"/>
+<use name="SimDataFormats/RandomEngine"/>
 <use name="SimG4Core/Notification"/>
 <use name="SimG4Core/Watcher"/>
 <flags EDM_PLUGIN="1"/>

--- a/Calo/interface/EcalStepWatcher.h
+++ b/Calo/interface/EcalStepWatcher.h
@@ -4,6 +4,7 @@
 //CMSSW headers
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h" 
+#include "SimDataFormats/RandomEngine/interface/RandomEngineState.h"
 #include "SimG4Core/Notification/interface/Observer.h"
 #include "SimG4Core/Watcher/interface/SimWatcher.h"
 
@@ -59,7 +60,7 @@ class EcalStepWatcher : public SimWatcher,
 		int ymax;
 		bool image_only;
 		bool reset_random;
-		std::vector<std::uint32_t> orig_seeds;
+		std::vector<RandomEngineState> orig_state;
 };
 
 #endif

--- a/Calo/interface/EcalStepWatcher.h
+++ b/Calo/interface/EcalStepWatcher.h
@@ -59,6 +59,7 @@ class EcalStepWatcher : public SimWatcher,
 		int ymax;
 		bool image_only;
 		bool reset_random;
+		std::vector<std::uint32_t> orig_seeds;
 };
 
 #endif

--- a/Calo/interface/EcalStepWatcher.h
+++ b/Calo/interface/EcalStepWatcher.h
@@ -58,6 +58,7 @@ class EcalStepWatcher : public SimWatcher,
 		int ymin;
 		int ymax;
 		bool image_only;
+		bool reset_random;
 };
 
 #endif

--- a/Calo/interface/EcalStepWatcher.h
+++ b/Calo/interface/EcalStepWatcher.h
@@ -34,7 +34,7 @@ class EcalStepWatcher : public SimWatcher,
 		struct SimNtuple {
 			double prim_pt, prim_eta, prim_phi, prim_E;
 			int prim_id;
-		        std::vector<double> step_x, step_y, step_z, step_t, step_E, bin_weights;
+			std::vector<double> step_x, step_y, step_z, step_t, step_E, bin_weights;
 		};
 
 	private:
@@ -49,14 +49,14 @@ class EcalStepWatcher : public SimWatcher,
 		std::unordered_set<std::string> volumes_;
 		edm::Service<TFileService> fs_;
 		TTree* tree_;
-		SimNtuple entry_;		
-      		TH2F * h2;
+		SimNtuple entry_;
+		TH2F * h2;
 		int xbins;
-                int ybins;
-                int xmin;
-                int xmax;
-                int ymin;
-                int ymax;
+		int ybins;
+		int xmin;
+		int xmax;
+		int ymin;
+		int ymax;
 		bool image_only;
 };
 

--- a/Calo/interface/EcalStepWatcher.h
+++ b/Calo/interface/EcalStepWatcher.h
@@ -4,7 +4,6 @@
 //CMSSW headers
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h" 
-#include "SimDataFormats/RandomEngine/interface/RandomEngineState.h"
 #include "SimG4Core/Notification/interface/Observer.h"
 #include "SimG4Core/Watcher/interface/SimWatcher.h"
 
@@ -60,7 +59,7 @@ class EcalStepWatcher : public SimWatcher,
 		int ymax;
 		bool image_only;
 		bool reset_random;
-		std::vector<RandomEngineState> orig_state;
+		std::vector<std::uint32_t> orig_seeds;
 };
 
 #endif

--- a/Calo/python/optGenSim.py
+++ b/Calo/python/optGenSim.py
@@ -38,6 +38,7 @@ options.register("ymax", 5, VarParsing.multiplicity.singleton, VarParsing.varTyp
 options.register("xbins", 100, VarParsing.multiplicity.singleton, VarParsing.varType.int, "number of x bins for image")
 options.register("ybins", 100, VarParsing.multiplicity.singleton, VarParsing.varType.int, "number of y bis for image")
 options.register("imageonly", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "only save image (not steps) in ntup tree")
+options.register("resetrandom", True, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "reset random number generator state for each event")
 options.register("paramNames", "", VarParsing.multiplicity.list, VarParsing.varType.string, "Geant4 parameters to modify (choices: {})".format(','.join(sorted(params))))
 options.register("paramValues", "", VarParsing.multiplicity.list, VarParsing.varType.float, "values for modified Geant4 parameters")
 

--- a/Calo/src/EcalStepWatcher.cc
+++ b/Calo/src/EcalStepWatcher.cc
@@ -19,7 +19,6 @@
 #include "G4SDManager.hh"
 #include "G4Step.hh"
 #include "Randomize.hh"
-#include "CLHEP/Random/RandFlat.h"
 
 //STL headers
 #include <algorithm>
@@ -101,19 +100,9 @@ void EcalStepWatcher::update(const BeginOfEvent* evt) {
 		}
 		//increment all seeds
 		std::for_each(orig_seeds.begin(), orig_seeds.end(), [](auto& n){ n++; });
-		//reset G4 seed explicitly
+		//reset G4 seed explicitly (also resets state consistently)
 		G4Random::setTheSeed(orig_seeds[0]);
 	}
-
-	//try printing random numbers
-	FakeStreamID fid(0);
-	edm::StreamID* sid(reinterpret_cast<edm::StreamID*>(&fid));
-	edm::Service<edm::RandomNumberGenerator> rng;
-	auto state_tmp = G4Random::getTheEngine()->put();
-	std::cout << "state: ";
-	std::for_each(state_tmp.begin(), state_tmp.end(), [](auto n){ std::cout << n << ", "; });
-	std::cout << std::endl;
-	std::cout << "random (begin): " << CLHEP::RandFlat::shoot(&(rng->getEngine(*sid))) << ", " << CLHEP::RandFlat::shoot(G4Random::getTheEngine()) << std::endl;
 
 	//reset branches
 	entry_ = SimNtuple();
@@ -167,12 +156,6 @@ void EcalStepWatcher::update(const EndOfEvent* evt) {
 
 	//fill tree
 	tree_->Fill();	
-
-	//try printing random numbers
-	FakeStreamID fid(0);
-	edm::StreamID* sid(reinterpret_cast<edm::StreamID*>(&fid));
-	edm::Service<edm::RandomNumberGenerator> rng;
-	std::cout << "random (end): " << CLHEP::RandFlat::shoot(&(rng->getEngine(*sid))) << ", " << CLHEP::RandFlat::shoot(G4Random::getTheEngine()) << std::endl;
 }
 
 DEFINE_SIMWATCHER(EcalStepWatcher);

--- a/Calo/src/EcalStepWatcher.cc
+++ b/Calo/src/EcalStepWatcher.cc
@@ -43,30 +43,30 @@ EcalStepWatcher::EcalStepWatcher(const edm::ParameterSet& iConfig)
 	tree_->Branch("prim_E",&entry_.prim_E,"prim_E/D");
 	tree_->Branch("prim_id",&entry_.prim_id,"prim_id/I");
 	if (!image_only){
-	    tree_->Branch("step_t" , "vector<double>", &entry_.step_t, 32000, 0);
-	    tree_->Branch("step_x" , "vector<double>", &entry_.step_x, 32000, 0);
-	    tree_->Branch("step_y" , "vector<double>", &entry_.step_y, 32000, 0);
-	    tree_->Branch("step_z" , "vector<double>", &entry_.step_z, 32000, 0);
-	    tree_->Branch("step_E" , "vector<double>", &entry_.step_E, 32000, 0);
-	    tree_->Branch("step_t" , "vector<double>", &entry_.step_t, 32000, 0);
+		tree_->Branch("step_t" , "vector<double>", &entry_.step_t, 32000, 0);
+		tree_->Branch("step_x" , "vector<double>", &entry_.step_x, 32000, 0);
+		tree_->Branch("step_y" , "vector<double>", &entry_.step_y, 32000, 0);
+		tree_->Branch("step_z" , "vector<double>", &entry_.step_z, 32000, 0);
+		tree_->Branch("step_E" , "vector<double>", &entry_.step_E, 32000, 0);
+		tree_->Branch("step_t" , "vector<double>", &entry_.step_t, 32000, 0);
 	}
 	else {
-	    tree_->Branch("bin_weights", "vector<double>", &entry_.bin_weights, 32000, 0);
-	    tree_->Branch("xbins",&xbins,"xbins/I");
-            tree_->Branch("ybins",&ybins,"ybins/I");
-            tree_->Branch("xmin",&xmin,"xmin/I");
-            tree_->Branch("xmax",&xmax,"xmax/I");
-            tree_->Branch("ymin",&ymin,"ymin/I");
-            tree_->Branch("ymax",&ymax,"ymax/I");
-	    h2 = new TH2F("h", "hist", xbins, xmin, xmax, ybins, ymin, ymax);
+		tree_->Branch("bin_weights", "vector<double>", &entry_.bin_weights, 32000, 0);
+		tree_->Branch("xbins",&xbins,"xbins/I");
+		tree_->Branch("ybins",&ybins,"ybins/I");
+		tree_->Branch("xmin",&xmin,"xmin/I");
+		tree_->Branch("xmax",&xmax,"xmax/I");
+		tree_->Branch("ymin",&ymin,"ymin/I");
+		tree_->Branch("ymax",&ymax,"ymax/I");
+		h2 = new TH2F("h", "hist", xbins, xmin, xmax, ybins, ymin, ymax);
 	}
 }
 
 void EcalStepWatcher::update(const BeginOfEvent* evt) {  
-        //reset branches
-  	entry_ = SimNtuple();
-  	if (image_only){
-	    h2->Reset("ICESM");
+	//reset branches
+	entry_ = SimNtuple();
+	if (image_only){
+		h2->Reset("ICESM");
 	}
 }
 
@@ -78,40 +78,40 @@ void EcalStepWatcher::update(const G4Step* step) {
 	std::string subname(name.substr(0,4));
 	if(volumes_.find(subname)==volumes_.end()) return;
 	if (!image_only){
-	    entry_.step_x.push_back(hitPoint.x());
-	    entry_.step_y.push_back(hitPoint.y());
-	    entry_.step_z.push_back(hitPoint.z());
-	    entry_.step_E.push_back(step->GetTotalEnergyDeposit()); 
-	    entry_.step_t.push_back(step->GetTrack()->GetGlobalTime());
-      	}
+		entry_.step_x.push_back(hitPoint.x());
+		entry_.step_y.push_back(hitPoint.y());
+		entry_.step_z.push_back(hitPoint.z());
+		entry_.step_E.push_back(step->GetTotalEnergyDeposit()); 
+		entry_.step_t.push_back(step->GetTrack()->GetGlobalTime());
+	}
 	else {
-	    h2->Fill(hitPoint.x(), hitPoint.y(), step->GetTotalEnergyDeposit());
+		h2->Fill(hitPoint.x(), hitPoint.y(), step->GetTotalEnergyDeposit());
 	}
 }
 
 void EcalStepWatcher::update(const EndOfEvent* evt) {
- 
+
 	//assume single particle gun
 	G4PrimaryParticle* prim = (*evt)()->GetPrimaryVertex(0)->GetPrimary(0);
 	TLorentzVector vprim;
 	vprim.SetPxPyPzE(prim->GetPx(),prim->GetPy(),prim->GetPz(),prim->GetTotalEnergy());
 	
-        entry_.prim_pt = vprim.Pt();
+	entry_.prim_pt = vprim.Pt();
 	entry_.prim_eta = vprim.Eta();
 	entry_.prim_phi = vprim.Phi();
 	entry_.prim_E = vprim.E();
 	entry_.prim_id = prim->GetPDGcode();
 
 	if (image_only) {
-	    // get bin weights from TH2 and store in tree
-	    Int_t x, y;
-	    h2->ClearUnderflowAndOverflow();
-	    entry_.bin_weights.reserve(xbins*ybins);
-	    for (x=1; x <= xbins; x++){
-	        for (y=1; y <= ybins; y++){
-		  entry_.bin_weights.push_back(h2->GetBinContent(x, y));
+		// get bin weights from TH2 and store in tree
+		Int_t x, y;
+		h2->ClearUnderflowAndOverflow();
+		entry_.bin_weights.reserve(xbins*ybins);
+		for (x=1; x <= xbins; x++){
+			for (y=1; y <= ybins; y++){
+				entry_.bin_weights.push_back(h2->GetBinContent(x, y));
+			}
 		}
-	    }
 	}
 
 	//fill tree

--- a/Calo/src/EcalStepWatcher.cc
+++ b/Calo/src/EcalStepWatcher.cc
@@ -7,6 +7,7 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/StreamID.h"
+#include "SimDataFormats/RandomEngine/interface/RandomEngineState.h"
 #include "SimG4Core/Watcher/interface/SimWatcherFactory.h"
 #include "SimG4Core/Notification/interface/BeginOfEvent.h"
 #include "SimG4Core/Notification/interface/BeginOfTrack.h"
@@ -87,24 +88,21 @@ void EcalStepWatcher::update(const BeginOfEvent* evt) {
 		//mockup of a stream ID: assume single thread
 		FakeStreamID fid(0);
 		edm::StreamID* sid(reinterpret_cast<edm::StreamID*>(&fid));
-		//make a copy of previous cache
-		std::vector<RandomEngineState> cache = rng->getEventCache(*sid);
-		for(auto& state : cache){
-			if(state.getLabel() == "g4SimHits"){
-				if(orig_state.empty()) {
-					orig_state.push_back(state);
+		//make a copy of initial cache
+		if(orig_seeds.empty()) {
+			std::vector<RandomEngineState> cache = rng->getEventCache(*sid);
+			for(auto& state : cache){
+				if(state.getLabel() == "g4SimHits"){
+					//store original state
+					orig_seeds = state.getSeed();
+					break;
 				}
-				auto seed_tmp = orig_state[0].getSeed();
-				//increment all seeds
-				std::for_each(seed_tmp.begin(), seed_tmp.end(), [](auto& n){ n++; });
-				orig_state[0].setSeed(seed_tmp);
-				//overwrite state (needed to set both seed and state for full reset)
-				state = orig_state[0];
-				break;
 			}
 		}
-		//force service to restore state from modified cache
-		rng->setEventCache(*sid,cache);
+		//increment all seeds
+		std::for_each(orig_seeds.begin(), orig_seeds.end(), [](auto& n){ n++; });
+		//reset G4 seed explicitly
+		G4Random::setTheSeed(orig_seeds[0]);
 	}
 
 	//try printing random numbers

--- a/Calo/src/EcalStepWatcher.cc
+++ b/Calo/src/EcalStepWatcher.cc
@@ -2,6 +2,7 @@
 #include "SimDenoising/Calo/interface/EcalStepWatcher.h"
 
 //CMSSW headers
+#include "DataFormats/Math/interface/LorentzVector.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
@@ -18,11 +19,10 @@
 #include "G4SDManager.hh"
 #include "G4Step.hh"
 
-//ROOT headers
-#include <TLorentzVector.h>
-
 //STL headers
 #include <algorithm>
+
+typedef math::XYZTLorentzVector LorentzVector;
 
 namespace {
 //modifiable class w/ same layout as edm::StreamID
@@ -131,13 +131,12 @@ void EcalStepWatcher::update(const EndOfEvent* evt) {
 
 	//assume single particle gun
 	G4PrimaryParticle* prim = (*evt)()->GetPrimaryVertex(0)->GetPrimary(0);
-	TLorentzVector vprim;
-	vprim.SetPxPyPzE(prim->GetPx(),prim->GetPy(),prim->GetPz(),prim->GetTotalEnergy());
-	
-	entry_.prim_pt = vprim.Pt();
-	entry_.prim_eta = vprim.Eta();
-	entry_.prim_phi = vprim.Phi();
-	entry_.prim_E = vprim.E();
+	LorentzVector vprim(prim->GetPx(),prim->GetPy(),prim->GetPz(),prim->GetTotalEnergy());
+
+	entry_.prim_pt = vprim.pt();
+	entry_.prim_eta = vprim.eta();
+	entry_.prim_phi = vprim.phi();
+	entry_.prim_E = vprim.energy();
 	entry_.prim_id = prim->GetPDGcode();
 
 	if (image_only) {

--- a/Calo/src/EcalStepWatcher.cc
+++ b/Calo/src/EcalStepWatcher.cc
@@ -111,6 +111,10 @@ void EcalStepWatcher::update(const BeginOfEvent* evt) {
 	FakeStreamID fid(0);
 	edm::StreamID* sid(reinterpret_cast<edm::StreamID*>(&fid));
 	edm::Service<edm::RandomNumberGenerator> rng;
+	auto state_tmp = G4Random::getTheEngine()->put();
+	std::cout << "state: ";
+	std::for_each(state_tmp.begin(), state_tmp.end(), [](auto n){ std::cout << n << ", "; });
+	std::cout << std::endl;
 	std::cout << "random (begin): " << CLHEP::RandFlat::shoot(&(rng->getEngine(*sid))) << ", " << CLHEP::RandFlat::shoot(G4Random::getTheEngine()) << std::endl;
 
 	//reset branches

--- a/Calo/src/EcalStepWatcher.cc
+++ b/Calo/src/EcalStepWatcher.cc
@@ -19,6 +19,7 @@
 #include "G4SDManager.hh"
 #include "G4Step.hh"
 #include "Randomize.hh"
+#include "CLHEP/Random/RandFlat.h"
 
 //STL headers
 #include <algorithm>
@@ -106,7 +107,15 @@ void EcalStepWatcher::update(const BeginOfEvent* evt) {
 		 rng->setEventCache(*sid,cache);
 		//make sure Geant4 uses this engine
 		G4Random::setTheEngine(&(rng->getEngine(*sid)));
+		//also set the seed explicitly
+		G4Random::setTheSeed(orig_seeds[0]);
 	}
+
+	//try printing random numbers
+	FakeStreamID fid(0);
+	edm::StreamID* sid(reinterpret_cast<edm::StreamID*>(&fid));
+	edm::Service<edm::RandomNumberGenerator> rng;
+	std::cout << "random (begin): " << CLHEP::RandFlat::shoot(&(rng->getEngine(*sid))) << ", " << CLHEP::RandFlat::shoot(G4Random::getTheEngine()) << std::endl;
 
 	//reset branches
 	entry_ = SimNtuple();
@@ -160,6 +169,12 @@ void EcalStepWatcher::update(const EndOfEvent* evt) {
 
 	//fill tree
 	tree_->Fill();	
+
+	//try printing random numbers
+	FakeStreamID fid(0);
+	edm::StreamID* sid(reinterpret_cast<edm::StreamID*>(&fid));
+	edm::Service<edm::RandomNumberGenerator> rng;
+	std::cout << "random (end): " << CLHEP::RandFlat::shoot(&(rng->getEngine(*sid))) << ", " << CLHEP::RandFlat::shoot(G4Random::getTheEngine()) << std::endl;
 }
 
 DEFINE_SIMWATCHER(EcalStepWatcher);

--- a/Calo/test/runSim.py
+++ b/Calo/test/runSim.py
@@ -98,6 +98,7 @@ process.g4SimHits.Watchers = cms.VPSet(
     cms.PSet(
         type = cms.string('EcalStepWatcher'),
         volumes = cms.vstring("EBRY","EFRY"),
+        reset_random = cms.bool(options.resetrandom),
         image_only = cms.bool(options.imageonly),
         xmin = cms.int32(options.xmin),
         xmax = cms.int32(options.xmax),

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-CMSSWVER=CMSSW_11_2_4
+CMSSWVER=CMSSW_11_0_3
 FORK=kpedro88
 BRANCH=master
 ACCESS=ssh
@@ -55,8 +55,6 @@ fi
 # get CMSSW release
 if [[ "$CMSSWVER" == "CMSSW_11_0_"* ]]; then
 	export SCRAM_ARCH=slc7_amd64_gcc820
-elif [[ "$CMSSWVER" == "CMSSW_11_2_"* ]]; then
-	export SCRAM_ARCH=slc7_amd64_gcc900
 else
 	echo "Unsupported CMSSW version: $CMSSWVER"
 	exit 1

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-CMSSWVER=CMSSW_11_0_3
+CMSSWVER=CMSSW_11_2_4
 FORK=kpedro88
 BRANCH=master
 ACCESS=ssh
@@ -55,6 +55,8 @@ fi
 # get CMSSW release
 if [[ "$CMSSWVER" == "CMSSW_11_0_"* ]]; then
 	export SCRAM_ARCH=slc7_amd64_gcc820
+elif [[ "$CMSSWVER" == "CMSSW_11_2_"* ]]; then
+	export SCRAM_ARCH=slc7_amd64_gcc900
 else
 	echo "Unsupported CMSSW version: $CMSSWVER"
 	exit 1


### PR DESCRIPTION
This option is added as an attempt to avoid or reduce cases where particles interact significantly differently when simulation settings are changed (e.g. a photon passes through the tracker with default settings, but converts with modified settings, because of changes in the random number sequence).